### PR TITLE
fixed notification error

### DIFF
--- a/abantecart/abc/templates/default/storefront/pages/account/notification.tpl
+++ b/abantecart/abc/templates/default/storefront/pages/account/notification.tpl
@@ -32,7 +32,7 @@
 		<?php } ?>
 		</tbody>
 
-		<?php if( count($transactions) ) { foreach ($transactions as $trn) { ?>
+		<?php if( isset($transactions) ) { foreach ($transactions as $trn) { ?>
 		<tr>
 			<td><?php echo $trn['customer_transaction_id']; ?></td>
 			<td><?php echo $trn['date_added']; ?></td>


### PR DESCRIPTION
## Description
when navigating to the notification tab the following error is shown
`count(): Argument #1 ($value) must be of type Countable|array, null given`
this PR solves the error
